### PR TITLE
Made specification duplicates validation case insensitive so that "io…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Java Client Library (beta)
-### v0.3.4
+### v0.3.5
 
 ## Introduction
 Welcome my friends! This is the Poly API Java client GitHub page. If you are here, then it means you're familiar with what we do at Poly. If you aren't, you can always check [here](https://github.com/polyapi/poly-alpha).
@@ -347,6 +347,8 @@ Comparing to its Typescript counterpart, the Java library is still missing the f
 These features will be added in the future releases.
 
 ## Changelog
+### v0.3.5
+- Made specification duplicates validation case insensitive so that 'io.polyapi.FunctionName' would be a duplicate of 'io.polyapi.Functionname'.
 ### v0.3.4
 - Added validation to avoid duplicate specifications based on context and name.
 ### v0.3.3

--- a/polyapi-maven-plugin/src/main/java/io/polyapi/plugin/service/SpecificationServiceImpl.java
+++ b/polyapi-maven-plugin/src/main/java/io/polyapi/plugin/service/SpecificationServiceImpl.java
@@ -36,7 +36,7 @@ public class SpecificationServiceImpl extends PolyApiService implements Specific
         logger.debug("Validating for duplicate context/name pairs.");
         Map<String, Specification> uniquenessValidationMap = new HashMap<>();
         specifications.forEach(specification -> {
-            String key = format("%s.%s", specification.getContext(), specification.getName());
+            String key = format("%s.%s", specification.getContext(), specification.getName()).toLowerCase();
             if (uniquenessValidationMap.containsKey(key)) {
                 logger.warn("Skipping {} specification '{}' in context '{}' as it clashes with {} specification with the same name and context.", specification.getType(), specification.getName(), specification.getContext(), uniquenessValidationMap.get(key).getType());
             } else {


### PR DESCRIPTION
….polyapi.FunctionName" would be a duplicate of "io.polyapi.Functionname".