### PR TITLE
Road to R30 take two

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,9 @@ Here's the list of parameters:
 - **host (required):** The host where the PolyAPI instance is hosted.
 - **port:** The port that the PolyAPI instance is listening to. Default value is 443.
 - **apiKey (required):** The API key required to authenticate to Poly.
-- **context:** Comma separated values that work as filter for the retrieved specifications. These filters will return any specification that starts with any of the indicated values. (i.e. if you set `polyapi,google` as a value, it will only generate those that have either of those as a context). This parameter is case-insensitive. 
+- **contexts:** Comma separated values that work as filter for the retrieved specifications. These filters will return any specification that starts with any of the indicated values. (i.e. if you set `polyapi,google` as a value, it will only generate those that have either of those as a context). This parameter is case-insensitive.
+- **context (legacy alias):** Backwards-compatible alias for `contexts`. If both are present, `contexts` takes precedence.
+- **functionIds:** Comma separated specification IDs to include during generation.
 - **overwrite:** Flag indicating that the generated files will overwrite any existing files. Default value is false.
 
 #### deploy-functions

--- a/polyapi-maven-plugin/src/main/java/io/polyapi/plugin/mojo/GenerateSourcesMojo.java
+++ b/polyapi-maven-plugin/src/main/java/io/polyapi/plugin/mojo/GenerateSourcesMojo.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static java.lang.String.join;
+import static java.util.function.Predicate.not;
 
 @Slf4j
 @Setter
@@ -24,7 +25,10 @@ public class GenerateSourcesMojo extends PolyApiMojo {
 
     @Parameter(property = "contexts")
     private String contexts;
-    
+
+    @Parameter(property = "context")
+    private String context;
+
     @Parameter(property = "functionIds")
     private String functionIds;
 
@@ -33,14 +37,36 @@ public class GenerateSourcesMojo extends PolyApiMojo {
     @Override
     public void execute(String host, Integer port) {
         log.info("Initiating generation of Poly sources.");
-        this.polyGenerationService = new PolyGenerationServiceImpl(getHttpClient(), getJsonParser(), host, port, getTokenProvider().getToken());
-        List<String> contextFilters = Arrays.stream(Optional.ofNullable(contexts).map(contextCsv -> contextCsv.split(",")).orElse(new String[]{""})).toList();
+        if (this.polyGenerationService == null) {
+            this.polyGenerationService = new PolyGenerationServiceImpl(getHttpClient(), getJsonParser(), host, port, getTokenProvider().getToken());
+        }
+
+        if (isDefined(contexts) && isDefined(context)) {
+            log.warn("Both 'contexts' and legacy 'context' parameters were provided. Using 'contexts'.");
+        }
+
+        String contextFilter = isDefined(contexts) ? contexts : context;
+        List<String> contextFilters = parseCsvFilter(contextFilter);
         log.debug("Context filters: \"{}\"", join("\", \"", contextFilters));
-       
-        List<String> functionIdFilters = Arrays.stream(Optional.ofNullable(functionIds).map(functionIdsCsv -> functionIdsCsv.split(",")).orElse(new String[]{""})).toList();
+
+        List<String> functionIdFilters = parseCsvFilter(functionIds);
         log.debug("Function ID filters: \"{}\"", join("\", \"", functionIdFilters));
-        
+
         this.polyGenerationService.generate(contextFilters, functionIdFilters, overwrite);
         log.info("Poly generation complete.");
+    }
+
+    static List<String> parseCsvFilter(String filter) {
+        return Arrays.stream(Optional.ofNullable(filter).orElse("").split(","))
+                .map(String::trim)
+                .filter(not(String::isBlank))
+                .toList();
+    }
+
+    private static boolean isDefined(String value) {
+        return Optional.ofNullable(value)
+                .map(String::trim)
+                .filter(not(String::isEmpty))
+                .isPresent();
     }
 }

--- a/polyapi-maven-plugin/src/main/java/io/polyapi/plugin/service/SpecificationServiceImpl.java
+++ b/polyapi-maven-plugin/src/main/java/io/polyapi/plugin/service/SpecificationServiceImpl.java
@@ -6,14 +6,13 @@ import io.polyapi.commons.api.service.PolyApiService;
 import io.polyapi.plugin.model.specification.IgnoredSpecification;
 import io.polyapi.plugin.model.specification.Specification;
 import io.polyapi.plugin.model.specification.function.ClientFunctionSpecification;
-import io.polyapi.plugin.model.specification.function.ServerFunctionSpecification;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.StringJoiner;
-import java.util.function.Predicate;
+import java.util.Optional;
 
 import static com.fasterxml.jackson.databind.type.TypeFactory.defaultInstance;
 import static java.lang.String.format;
@@ -30,30 +29,71 @@ public class SpecificationServiceImpl extends PolyApiService implements Specific
     @Override
     public List<Specification> list(List<String> contextFilters, List<String> functionIdFilters) {
         log.info("Retrieving JSON specifications from PolyAPI for this user.");
-        
-        // Build the query parameter string for server-side filtering
-        StringJoiner queryParams = new StringJoiner("&");
-        if (contextFilters != null && !contextFilters.isEmpty()) {
-            queryParams.add("contexts=" + String.join(",", contextFilters));
+
+        List<String> sanitizedContextFilters = sanitizeFilters(contextFilters);
+        List<String> sanitizedFunctionIdFilters = sanitizeFilters(functionIdFilters);
+
+        Map<String, List<String>> queryParams = new HashMap<>();
+        if (!sanitizedContextFilters.isEmpty()) {
+            queryParams.put("contexts", List.of(String.join(",", sanitizedContextFilters)));
         }
-        if (functionIdFilters != null && !functionIdFilters.isEmpty()) {
-            queryParams.add("ids=" + String.join(",", functionIdFilters));
+        if (!sanitizedFunctionIdFilters.isEmpty()) {
+            queryParams.put("ids", List.of(String.join(",", sanitizedFunctionIdFilters)));
+        }
+        if (!queryParams.isEmpty()) {
+            log.info("Applying server-side filters: {}", queryParams);
         }
 
-        String path = "specs";
-        if (queryParams.length() > 0) {
-            path += "?" + queryParams.toString();
-            log.info("Applying server-side filters: {}", queryParams.toString());
-        }
-
-        // Make the API call with the constructed path
-        List<Specification> specifications = get(path, defaultInstance().constructCollectionType(List.class, Specification.class));
+        List<Specification> specifications = get("specs", new HashMap<>(), queryParams, defaultInstance().constructCollectionType(List.class, Specification.class));
 
         if (log.isTraceEnabled()) {
             log.trace("Retrieved specifications with the following IDs: [{}]", specifications.stream().map(Specification::getId).collect(joining(", ")));
         }
 
-        log.info("{} specifications retrieved after server-side filtering.", specifications.size());
-        return specifications;
+        Map<String, Specification> filteredMap = new LinkedHashMap<>();
+        specifications.stream()
+                .filter(not(IgnoredSpecification.class::isInstance))
+                .filter(specification -> specificationMatchesContextFilters(specification, sanitizedContextFilters))
+                .filter(specification -> specificationMatchesIdFilters(specification, sanitizedFunctionIdFilters))
+                .filter(not(specification -> specification instanceof ClientFunctionSpecification clientFunctionSpecification && !clientFunctionSpecification.isJava()))
+                .forEach(specification -> {
+                    String key = format("%s.%s", specification.getContext(), specification.getName()).toLowerCase();
+                    if (filteredMap.containsKey(key)) {
+                        log.warn("Skipping {} specification '{}' in context '{}' as it clashes with {} specification with the same name and context.",
+                                specification.getType(), specification.getName(), specification.getContext(), filteredMap.get(key).getType());
+                    } else {
+                        filteredMap.put(key, specification);
+                    }
+                });
+        List<Specification> result = filteredMap.values().stream().toList();
+        log.info("{} specifications retrieved after server and local filtering.", result.size());
+        return result;
+    }
+
+    private List<String> sanitizeFilters(List<String> filters) {
+        return Optional.ofNullable(filters)
+                .orElse(List.of())
+                .stream()
+                .filter(java.util.Objects::nonNull)
+                .map(String::trim)
+                .filter(not(String::isBlank))
+                .toList();
+    }
+
+    private boolean specificationMatchesContextFilters(Specification specification, List<String> contextFilters) {
+        if (contextFilters.isEmpty()) {
+            return true;
+        }
+        String context = Optional.ofNullable(specification.getContext()).orElse("").trim().toLowerCase();
+        return contextFilters.stream()
+                .map(String::toLowerCase)
+                .anyMatch(contextFilter -> contextFilter.equals(context) || context.startsWith(format("%s.", contextFilter)));
+    }
+
+    private boolean specificationMatchesIdFilters(Specification specification, List<String> functionIdFilters) {
+        if (functionIdFilters.isEmpty()) {
+            return true;
+        }
+        return functionIdFilters.stream().anyMatch(idFilter -> idFilter.equals(specification.getId()));
     }
 }

--- a/polyapi-maven-plugin/src/test/java/io/polyapi/plugin/mojo/GenerateSourcesMojoTest.java
+++ b/polyapi-maven-plugin/src/test/java/io/polyapi/plugin/mojo/GenerateSourcesMojoTest.java
@@ -1,0 +1,78 @@
+package io.polyapi.plugin.mojo;
+
+import io.polyapi.plugin.service.generation.PolyGenerationService;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class GenerateSourcesMojoTest {
+
+    @Test
+    void parseCsvFilterDropsBlankValues() {
+        assertEquals(List.of("alpha", "beta"), GenerateSourcesMojo.parseCsvFilter(" alpha, ,beta,,  "));
+        assertEquals(List.of(), GenerateSourcesMojo.parseCsvFilter(null));
+        assertEquals(List.of(), GenerateSourcesMojo.parseCsvFilter(" , , "));
+    }
+
+    @Test
+    void executeUsesLegacyContextWhenContextsIsNotSet() {
+        GenerateSourcesMojo mojo = new GenerateSourcesMojo();
+        CapturingPolyGenerationService capturingService = new CapturingPolyGenerationService();
+        mojo.setPolyGenerationService(capturingService);
+        mojo.setContext("legacy, child");
+        mojo.setFunctionIds("id-1, id-2");
+        mojo.setOverwrite(Boolean.TRUE);
+
+        mojo.execute("https://polyapi.io", 443);
+
+        assertEquals(List.of("legacy", "child"), capturingService.contextFilters);
+        assertEquals(List.of("id-1", "id-2"), capturingService.functionIdFilters);
+        assertEquals(Boolean.TRUE, capturingService.overwrite);
+    }
+
+    @Test
+    void executePrefersContextsOverLegacyContext() {
+        GenerateSourcesMojo mojo = new GenerateSourcesMojo();
+        CapturingPolyGenerationService capturingService = new CapturingPolyGenerationService();
+        mojo.setPolyGenerationService(capturingService);
+        mojo.setContext("legacy");
+        mojo.setContexts("preferred");
+        mojo.setFunctionIds(" , ");
+        mojo.setOverwrite(Boolean.FALSE);
+
+        mojo.execute("https://polyapi.io", 443);
+
+        assertEquals(List.of("preferred"), capturingService.contextFilters);
+        assertEquals(List.of(), capturingService.functionIdFilters);
+        assertEquals(Boolean.FALSE, capturingService.overwrite);
+    }
+
+    @Test
+    void executeFallsBackToLegacyContextWhenContextsIsBlank() {
+        GenerateSourcesMojo mojo = new GenerateSourcesMojo();
+        CapturingPolyGenerationService capturingService = new CapturingPolyGenerationService();
+        mojo.setPolyGenerationService(capturingService);
+        mojo.setContext("legacy");
+        mojo.setContexts("   ");
+        mojo.setOverwrite(Boolean.FALSE);
+
+        mojo.execute("https://polyapi.io", 443);
+
+        assertEquals(List.of("legacy"), capturingService.contextFilters);
+    }
+
+    private static class CapturingPolyGenerationService implements PolyGenerationService {
+        private List<String> contextFilters;
+        private List<String> functionIdFilters;
+        private Boolean overwrite;
+
+        @Override
+        public void generate(List<String> contextFilters, List<String> functionIdFilters, boolean overwrite) {
+            this.contextFilters = contextFilters;
+            this.functionIdFilters = functionIdFilters;
+            this.overwrite = overwrite;
+        }
+    }
+}

--- a/polyapi-maven-plugin/src/test/java/io/polyapi/plugin/service/SpecificationServiceImplTest.java
+++ b/polyapi-maven-plugin/src/test/java/io/polyapi/plugin/service/SpecificationServiceImplTest.java
@@ -1,8 +1,122 @@
 package io.polyapi.plugin.service;
 
+import io.polyapi.plugin.model.specification.IgnoredSpecification;
+import io.polyapi.plugin.model.specification.Specification;
+import io.polyapi.plugin.model.specification.function.ClientFunctionSpecification;
+import io.polyapi.plugin.model.specification.function.ServerFunctionSpecification;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 /**
- * Test class for {@link PolyFunctionServiceImpl}.
+ * Test class for {@link SpecificationServiceImpl}.
  */
 public class SpecificationServiceImplTest {
-    // FIXME: Add tests.
+
+    @Test
+    void listDoesNotSendEmptyQueryParams() {
+        StubSpecificationService service = new StubSpecificationService(List.of());
+
+        List<Specification> result = service.list(List.of("", "   "), Arrays.asList(" ", null));
+
+        assertEquals("specs", service.capturedRelativePath);
+        assertTrue(service.capturedQueryParams.isEmpty());
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void listSanitizesAndSendsServerSideFilters() {
+        StubSpecificationService service = new StubSpecificationService(List.of(serverSpec("id-1", "alpha", "fn")));
+
+        List<Specification> result = service.list(List.of(" alpha ", " "), List.of(" id-1 ", ""));
+
+        assertEquals(1, result.size());
+        assertEquals(Map.of("contexts", List.of("alpha"), "ids", List.of("id-1")), service.capturedQueryParams);
+    }
+
+    @Test
+    void listAppliesFallbackFilteringAndDeduplication() {
+        Specification duplicateCandidate = serverSpec("id-dup", "alpha", "shared");
+        Specification includedDirectMatch = serverSpec("id-1", "alpha", "shared");
+        Specification includedNestedContext = serverSpec("id-2", "alpha.child", "childFn");
+        Specification excludedByContext = serverSpec("id-other", "beta", "otherFn");
+        Specification excludedByLanguage = clientSpec("id-js", "alpha", "jsFn", "javascript");
+        Specification excludedIgnoredType = ignoredSpec("id-ignored", "alpha", "ignoredFn");
+
+        StubSpecificationService service = new StubSpecificationService(List.of(
+                includedDirectMatch,
+                duplicateCandidate,
+                includedNestedContext,
+                excludedByContext,
+                excludedByLanguage,
+                excludedIgnoredType
+        ));
+
+        List<Specification> result = service.list(
+                List.of("alpha"),
+                List.of("id-1", "id-2", "id-dup", "id-other", "id-js", "id-ignored")
+        );
+
+        assertEquals(List.of("id-1", "id-2"), result.stream().map(Specification::getId).toList());
+        assertEquals(Map.of(
+                "contexts", List.of("alpha"),
+                "ids", List.of("id-1,id-2,id-dup,id-other,id-js,id-ignored")
+        ), service.capturedQueryParams);
+    }
+
+    private static ServerFunctionSpecification serverSpec(String id, String context, String name) {
+        ServerFunctionSpecification specification = new ServerFunctionSpecification();
+        specification.setId(id);
+        specification.setType("serverFunction");
+        specification.setContext(context);
+        specification.setName(name);
+        specification.setLanguage("java");
+        return specification;
+    }
+
+    private static ClientFunctionSpecification clientSpec(String id, String context, String name, String language) {
+        ClientFunctionSpecification specification = new ClientFunctionSpecification();
+        specification.setId(id);
+        specification.setType("customFunction");
+        specification.setContext(context);
+        specification.setName(name);
+        specification.setLanguage(language);
+        return specification;
+    }
+
+    private static IgnoredSpecification ignoredSpec(String id, String context, String name) {
+        IgnoredSpecification specification = new IgnoredSpecification();
+        specification.setId(id);
+        specification.setType("unknown");
+        specification.setContext(context);
+        specification.setName(name);
+        return specification;
+    }
+
+    private static class StubSpecificationService extends SpecificationServiceImpl {
+        private final List<Specification> response;
+        private String capturedRelativePath;
+        private Map<String, List<String>> capturedQueryParams = Map.of();
+
+        private StubSpecificationService(List<Specification> response) {
+            super(null, null, "https://polyapi.io", 443);
+            this.response = response;
+        }
+
+        @Override
+        public <O> O get(String relativePath, Map<String, List<String>> headers, Map<String, List<String>> queryParams, Type expectedResponseType) {
+            this.capturedRelativePath = relativePath;
+            this.capturedQueryParams = new HashMap<>(queryParams);
+            @SuppressWarnings("unchecked")
+            O casted = (O) response;
+            return casted;
+        }
+    }
 }


### PR DESCRIPTION
EN Fix generate-sources filtering: support legacy context, sanitize empty filters, and restore spec dedupe